### PR TITLE
feat: attach customer documents while creating an invoice (PC + mobile)

### DIFF
--- a/app/Console/Commands/PurgePendingAttachments.php
+++ b/app/Console/Commands/PurgePendingAttachments.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Attachment;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+class PurgePendingAttachments extends Command
+{
+    protected $signature = 'attachments:purge-pending {--hours=48 : Delete pending uploads older than this many hours}';
+
+    protected $description = 'Delete abandoned pending (unlinked) document uploads and their files';
+
+    public function handle(): int
+    {
+        $hours  = (int) $this->option('hours');
+        $cutoff = now()->subHours($hours);
+
+        $stale = Attachment::stalePending($cutoff)->get();
+
+        $deleted = 0;
+        foreach ($stale as $att) {
+            $full = public_path($att->file_path);
+            if (is_file($full)) {
+                @unlink($full);
+            }
+            $att->delete();
+            $deleted++;
+        }
+
+        // Remove any now-empty pending directories.
+        $pendingRoot = public_path('attachments/pending');
+        if (is_dir($pendingRoot)) {
+            foreach (File::directories($pendingRoot) as $dir) {
+                if (count((array) glob($dir . '/*')) === 0) {
+                    @rmdir($dir);
+                }
+            }
+        }
+
+        $this->info("Purged {$deleted} abandoned pending attachment(s) older than {$hours}h.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/AttachmentController.php
+++ b/app/Http/Controllers/AttachmentController.php
@@ -20,6 +20,11 @@ class AttachmentController extends Controller
 
     public function store(Request $request)
     {
+        // ── Pending mode: uploaded from the Create screen before the parent exists ──
+        if ($request->filled('upload_token') && ! $request->filled('attachable_id')) {
+            return $this->storePending($request);
+        }
+
         $request->validate([
             'attachable_type' => 'required|in:invoice,purchase',
             'attachable_id'   => 'required|integer',
@@ -33,41 +38,157 @@ class AttachmentController extends Controller
 
         $uploaded = [];
         foreach ($request->file('files') as $file) {
-            // Capture metadata BEFORE move()
-            $origName  = $file->getClientOriginalName();
-            $mimeType  = $file->getClientMimeType();
-            $fileSize  = $file->getSize();
-            $extension = $file->getClientOriginalExtension();
-
-            $folder   = "attachments/{$type}/{$model->id}";
-            File::ensureDirectoryExists(public_path($folder));
-            $filename = date('YmdHis') . '_' . Str::slug(pathinfo($origName, PATHINFO_FILENAME)) . '.' . $extension;
-            $file->move(public_path($folder), $filename);
-
-            $attachment = Attachment::create([
+            $attachment = $this->storeFile($file, "attachments/{$type}/{$model->id}", [
                 'attachable_type' => $modelClass,
                 'attachable_id'   => $model->id,
-                'file_path'       => $folder . '/' . $filename,
-                'file_name'       => $origName,
-                'file_type'       => $mimeType,
-                'file_size'       => $fileSize,
                 'label'           => $request->label ?? null,
                 'uploaded_by'     => Auth::id(),
             ]);
-
-            $uploaded[] = [
-                'id'             => $attachment->id,
-                'file_name'      => $attachment->file_name,
-                'file_type'      => $attachment->file_type,
-                'formatted_size' => $attachment->formatted_size,
-                'url'            => $attachment->url,
-                'label'          => $attachment->label,
-                'is_image'       => $attachment->isImage(),
-                'is_pdf'         => $attachment->isPdf(),
-            ];
+            $uploaded[] = $this->formatAttachment($attachment);
         }
 
         return response()->json(['success' => true, 'attachments' => $uploaded]);
+    }
+
+    // ─── Authenticated: pending upload (Create screen, before parent exists) ────
+
+    /**
+     * Store files into a pending bucket keyed by an upload-session token.
+     * Rows keep a null attachable_id until the invoice is saved and
+     * attachPendingToInvoice() links them.
+     */
+    protected function storePending(Request $request)
+    {
+        $request->validate([
+            'upload_token' => 'required|string|max:64',
+            'files'        => 'required|array|min:1',
+            'files.*'      => 'required|file|mimes:jpg,jpeg,png,gif,webp,pdf|max:10240',
+            'label'        => 'nullable|string|max:100',
+        ]);
+
+        $token   = $request->upload_token;
+        $session = Cache::get('mm_upload_token_' . $token);
+
+        if (! $session || empty($session['pending'])) {
+            return response()->json([
+                'success' => false,
+                'message' => 'This upload session has expired. Please reload the page and try again.',
+            ], 403);
+        }
+
+        [$modelClass] = $this->resolveModel($session['type'] ?? 'invoice');
+
+        $uploaded = [];
+        foreach ($request->file('files') as $file) {
+            $attachment = $this->storeFile($file, "attachments/pending/{$token}", [
+                'attachable_type' => $modelClass,
+                'attachable_id'   => null,
+                'upload_token'    => $token,
+                'label'           => $request->label ?? null,
+                'uploaded_by'     => Auth::id(),
+            ]);
+            $uploaded[] = $this->formatAttachment($attachment);
+        }
+
+        return response()->json(['success' => true, 'attachments' => $uploaded]);
+    }
+
+    /** Return the current pending uploads for a token (the Create screen polls this). */
+    public function listPending(string $token)
+    {
+        $attachments = Attachment::pendingForToken($token)
+            ->orderBy('created_at')
+            ->get()
+            ->map(fn (Attachment $a) => $this->formatAttachment($a))
+            ->values();
+
+        return response()->json(['success' => true, 'attachments' => $attachments]);
+    }
+
+    // ─── Shared helpers ─────────────────────────────────────────────────────────
+
+    /**
+     * Move an uploaded file into $folder (under public/) and create its Attachment row.
+     * A short random suffix keeps filenames unique when several files land in the same
+     * second (e.g. a phone and a laptop uploading at once).
+     */
+    protected function storeFile($file, string $folder, array $attributes): Attachment
+    {
+        // Capture metadata BEFORE move()
+        $origName  = $file->getClientOriginalName();
+        $mimeType  = $file->getClientMimeType();
+        $fileSize  = $file->getSize();
+        $extension = $file->getClientOriginalExtension();
+
+        File::ensureDirectoryExists(public_path($folder));
+        $filename = date('YmdHis') . '_' . Str::random(6) . '_'
+            . Str::slug(pathinfo($origName, PATHINFO_FILENAME)) . '.' . $extension;
+        $file->move(public_path($folder), $filename);
+
+        return Attachment::create(array_merge([
+            'file_path' => $folder . '/' . $filename,
+            'file_name' => $origName,
+            'file_type' => $mimeType,
+            'file_size' => $fileSize,
+        ], $attributes));
+    }
+
+    /** Shape an Attachment for the JSON the panel JS consumes. */
+    protected function formatAttachment(Attachment $attachment): array
+    {
+        return [
+            'id'             => $attachment->id,
+            'file_name'      => $attachment->file_name,
+            'file_type'      => $attachment->file_type,
+            'formatted_size' => $attachment->formatted_size,
+            'url'            => $attachment->url,
+            'label'          => $attachment->label,
+            'is_image'       => $attachment->isImage(),
+            'is_pdf'         => $attachment->isPdf(),
+        ];
+    }
+
+    /**
+     * Link all pending uploads for $token to the freshly-created invoice and move
+     * their files from the pending bucket into the invoice's own folder. Safe to call
+     * with a null/empty token. Returns the number of files linked.
+     */
+    public static function attachPendingToInvoice(?string $token, Invoice $invoice): int
+    {
+        if (empty($token)) {
+            return 0;
+        }
+
+        $pending = Attachment::pendingForToken($token)->get();
+        $moved   = 0;
+
+        foreach ($pending as $att) {
+            $newFolder = "attachments/invoice/{$invoice->id}";
+            File::ensureDirectoryExists(public_path($newFolder));
+
+            $newPath = $newFolder . '/' . basename($att->file_path);
+            $oldFull = public_path($att->file_path);
+            $newFull = public_path($newPath);
+
+            if (is_file($oldFull) && @rename($oldFull, $newFull)) {
+                $att->file_path = $newPath;
+            }
+
+            $att->attachable_type = Invoice::class;
+            $att->attachable_id   = $invoice->id;
+            $att->upload_token    = null;
+            $att->save();
+            $moved++;
+        }
+
+        // Best-effort cleanup of the now-empty pending directory + token.
+        $dir = public_path("attachments/pending/{$token}");
+        if (is_dir($dir) && count((array) glob($dir . '/*')) === 0) {
+            @rmdir($dir);
+        }
+        Cache::forget('mm_upload_token_' . $token);
+
+        return $moved;
     }
 
     // ─── Authenticated: delete ────────────────────────────────────────────────
@@ -125,6 +246,17 @@ class AttachmentController extends Controller
             return view('attachments.expired');
         }
 
+        // Pending session — the parent (e.g. a new invoice) isn't created yet.
+        if (! empty($data['pending'])) {
+            return view('attachments.mobile-upload', [
+                'token'   => $token,
+                'type'    => $data['type'],
+                'id'      => null,
+                'model'   => null,
+                'pending' => true,
+            ]);
+        }
+
         [$modelClass] = $this->resolveModel($data['type']);
         $model = $modelClass::find($data['id']);
 
@@ -133,10 +265,11 @@ class AttachmentController extends Controller
         }
 
         return view('attachments.mobile-upload', [
-            'token' => $token,
-            'type'  => $data['type'],
-            'id'    => $data['id'],
-            'model' => $model,
+            'token'   => $token,
+            'type'    => $data['type'],
+            'id'      => $data['id'],
+            'model'   => $model,
+            'pending' => false,
         ]);
     }
 
@@ -157,31 +290,26 @@ class AttachmentController extends Controller
         ]);
 
         [$modelClass, $type] = $this->resolveModel($data['type']);
-        $id = $data['id'];
+        $isPending = ! empty($data['pending']);
 
         $uploaded = 0;
         foreach ($request->file('files') as $file) {
-            // Capture metadata BEFORE move()
-            $origName  = $file->getClientOriginalName();
-            $mimeType  = $file->getClientMimeType();
-            $fileSize  = $file->getSize();
-            $extension = $file->getClientOriginalExtension();
-
-            $folder   = "attachments/{$type}/{$id}";
-            File::ensureDirectoryExists(public_path($folder));
-            $filename = date('YmdHis') . '_' . Str::slug(pathinfo($origName, PATHINFO_FILENAME)) . '.' . $extension;
-            $file->move(public_path($folder), $filename);
-
-            Attachment::create([
-                'attachable_type' => $modelClass,
-                'attachable_id'   => $id,
-                'file_path'       => $folder . '/' . $filename,
-                'file_name'       => $origName,
-                'file_type'       => $mimeType,
-                'file_size'       => $fileSize,
-                'label'           => $request->label ?? null,
-                'uploaded_by'     => null, // mobile = no auth
-            ]);
+            if ($isPending) {
+                $this->storeFile($file, "attachments/pending/{$token}", [
+                    'attachable_type' => $modelClass,
+                    'attachable_id'   => null,
+                    'upload_token'    => $token,
+                    'label'           => $request->label ?? null,
+                    'uploaded_by'     => null, // mobile = no auth
+                ]);
+            } else {
+                $this->storeFile($file, "attachments/{$type}/{$data['id']}", [
+                    'attachable_type' => $modelClass,
+                    'attachable_id'   => $data['id'],
+                    'label'           => $request->label ?? null,
+                    'uploaded_by'     => null, // mobile = no auth
+                ]);
+            }
             $uploaded++;
         }
 
@@ -206,8 +334,9 @@ class AttachmentController extends Controller
         $purchaseLabels = ['Original Bill', 'Device Photo', 'Box Photo', 'Accessories Photo', 'Other Document'];
         $allLabels      = array_unique(array_merge($invoiceLabels, $purchaseLabels));
 
-        // Invoice attachments
+        // Invoice attachments (exclude not-yet-linked pending uploads)
         $invoiceAtts = Attachment::where('attachable_type', Invoice::class)
+            ->whereNotNull('attachable_id')
             ->with(['attachable', 'uploader'])
             ->when($label,  fn($q) => $q->where('label', $label))
             ->when($search, fn($q) => $q->whereHas('attachable', fn($sq) =>
@@ -225,8 +354,9 @@ class AttachmentController extends Controller
             ->paginate(20, ['*'], 'ipage')
             ->withQueryString();
 
-        // Purchase attachments
+        // Purchase attachments (exclude not-yet-linked pending uploads)
         $purchaseAtts = Attachment::where('attachable_type', Purchase::class)
+            ->whereNotNull('attachable_id')
             ->with(['attachable', 'uploader'])
             ->when($label,  fn($q) => $q->where('label', $label))
             ->when($search, fn($q) => $q->whereHas('attachable', fn($sq) =>
@@ -267,6 +397,7 @@ class AttachmentController extends Controller
         $dateField  = $isInvoice ? 'invoice_date' : 'purchase_date';
 
         $query = Attachment::where('attachable_type', $modelClass)
+            ->whereNotNull('attachable_id')
             ->with(['attachable', 'uploader'])
             ->when($label, fn($q) => $q->where('label', $label));
 

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -11,7 +11,10 @@ use Carbon\Carbon;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class InvoiceController extends Controller
 {
@@ -50,9 +53,19 @@ class InvoiceController extends Controller
 
         $formattedNumber = 'MF'.$currentYear.mb_str_pad((string) $nextInvoiceNo, 4, '0', STR_PAD_LEFT);
 
+        // Pending upload session: lets the user attach documents (PC + phone/QR)
+        // on this Create screen before the invoice is saved. Files are linked to
+        // the invoice on submit by AttachmentController::attachPendingToInvoice().
+        $uploadToken = Str::random(48);
+        Cache::put('mm_upload_token_'.$uploadToken, [
+            'type'    => 'invoice',
+            'pending' => true,
+        ], now()->addHours(24));
+
         return view('invoice.add', [
             'stocksModel' => $stocksModel,
             'lastId' => $formattedNumber,
+            'uploadToken' => $uploadToken,
         ]);
     }
 
@@ -162,6 +175,14 @@ class InvoiceController extends Controller
             }
 
             DB::commit();
+
+            // Link any documents the user attached on the Create screen (PC + phone)
+            // to this invoice. Best-effort: a file issue must not break invoice creation.
+            try {
+                AttachmentController::attachPendingToInvoice($request->upload_token, $invoice);
+            } catch (Exception $e) {
+                Log::warning('Failed to link pending attachments to invoice '.$invoice->id.': '.$e->getMessage());
+            }
 
             // Handle Google contact sync
             if ($request->customer_no_sync === 'on') {

--- a/app/Models/Attachment.php
+++ b/app/Models/Attachment.php
@@ -19,6 +19,26 @@ class Attachment extends Model
         return $this->belongsTo(User::class, 'uploaded_by');
     }
 
+    /** Pending (not yet linked to a parent) uploads for a given upload session token */
+    public function scopePendingForToken($q, string $token)
+    {
+        return $q->whereNull('attachable_id')->where('upload_token', $token);
+    }
+
+    /** All stale pending uploads created before the given cutoff */
+    public function scopeStalePending($q, $cutoff)
+    {
+        return $q->whereNull('attachable_id')
+            ->whereNotNull('upload_token')
+            ->where('created_at', '<', $cutoff);
+    }
+
+    /** True while the file is still in the pending bucket (no parent yet) */
+    public function isPending(): bool
+    {
+        return $this->attachable_id === null && ! empty($this->upload_token);
+    }
+
     /** Public URL for serving the file */
     public function getUrlAttribute(): string
     {

--- a/database/migrations/2026_08_16_000001_add_upload_token_to_attachments_table.php
+++ b/database/migrations/2026_08_16_000001_add_upload_token_to_attachments_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Add the pending-upload token column.
+        Schema::table('attachments', function (Blueprint $table) {
+            $table->string('upload_token', 64)->nullable()->index()->after('uploaded_by');
+        });
+
+        // Allow a "pending" attachment to exist before its parent (invoice) is saved.
+        Schema::table('attachments', function (Blueprint $table) {
+            $table->unsignedBigInteger('attachable_id')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('attachments', function (Blueprint $table) {
+            $table->dropIndex(['upload_token']);
+            $table->dropColumn('upload_token');
+        });
+
+        // Restore NOT NULL. (Any leftover pending rows must be cleared first.)
+        Schema::table('attachments', function (Blueprint $table) {
+            $table->unsignedBigInteger('attachable_id')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/attachments/mobile-upload.blade.php
+++ b/resources/views/attachments/mobile-upload.blade.php
@@ -275,14 +275,18 @@
 <div class="info-card">
     <span class="badge">{{ ucfirst($type) }}</span>
     <div class="title">
-        @if($type === 'invoice')
+        @if(empty($model))
+            New {{ ucfirst($type) }} (being created)
+        @elseif($type === 'invoice')
             Invoice #{{ $model->invoice_no }}
         @else
             Stock — {{ $model->model }} ({{ $model->imei }})
         @endif
     </div>
     <div class="meta">
-        @if($type === 'invoice')
+        @if(empty($model))
+            Upload documents here — they'll attach automatically when the {{ $type }} is saved on the computer.
+        @elseif($type === 'invoice')
             Customer: {{ $model->customer_name }} &bull; {{ \Carbon\Carbon::parse($model->invoice_date)->format('d M Y') }}
         @else
             {{ $model->brand ?? '' }} {{ $model->storage ?? '' }} &bull; {{ ucfirst($model->color ?? '') }}
@@ -292,7 +296,9 @@
 
 {{-- Already uploaded files --}}
 @php
-    $existing = $model->attachments()->latest()->get();
+    $existing = ! empty($model)
+        ? $model->attachments()->latest()->get()
+        : \App\Models\Attachment::pendingForToken($token)->latest()->get();
 @endphp
 @if($existing->count() > 0)
 <div class="uploaded-section">

--- a/resources/views/include/attachments-panel.blade.php
+++ b/resources/views/include/attachments-panel.blade.php
@@ -1,21 +1,34 @@
 {{--
     Reusable attachments panel.
-    Required variables:
+    Linked mode (existing parent record):
       $attachable      – the Invoice or Purchase model instance
       $attachableType  – 'invoice' or 'purchase'
       $attachableId    – $attachable->id
-    Optional:
+    Pending mode (parent not created yet, e.g. Create Invoice screen):
+      $pendingMode     – true
+      $pendingToken    – the upload-session token
+      $attachableType  – 'invoice' or 'purchase'
+    Optional (both modes):
       $labelOptions    – array of suggested label strings
 --}}
 @php
-    $attachments   = $attachable->attachments()->get();
+    $pendingMode  = $pendingMode ?? false;
+    $pendingToken = $pendingToken ?? null;
+
+    $attachments = $pendingMode
+        ? \App\Models\Attachment::pendingForToken($pendingToken)->orderBy('created_at')->get()
+        : $attachable->attachments()->get();
+
     $defaultLabels = $attachableType === 'invoice'
         ? ['Aadhaar Card', 'PAN Card', 'Driving Licence', 'Voter ID', 'Passport', 'Other ID Proof']
         : ['Original Bill', 'Device Photo', 'Box Photo', 'Accessories Photo', 'Other Document'];
     $labelOpts   = $labelOptions ?? $defaultLabels;
-    $tokenRoute  = route('attachments.token', ['type' => $attachableType, 'id' => $attachableId]);
-    $storeRoute  = route('attachments.store');
-    $panelId     = $attachableType . '-' . $attachableId;
+
+    $storeRoute      = route('attachments.store');
+    $tokenRoute      = $pendingMode ? null : route('attachments.token', ['type' => $attachableType, 'id' => $attachableId]);
+    $mobileUploadUrl = $pendingMode ? route('attachments.mobile-upload', ['token' => $pendingToken]) : null;
+    $listPendingUrl  = $pendingMode ? route('attachments.pending', ['token' => $pendingToken]) : null;
+    $panelId         = $pendingMode ? 'invoice-pending' : ($attachableType . '-' . $attachableId);
 @endphp
 
 {{-- ── Styles (injected once into <head>) ────────────────────────────────── --}}
@@ -33,6 +46,14 @@
 }
 .att-panel-header h5 { margin: 0; font-size: 0.95rem; font-weight: 700; }
 .att-btn-group { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+
+/* ── Mobile: stack title over full-width, evenly-split action buttons ────── */
+@media (max-width: 575.98px) {
+    .att-panel-header { flex-direction: column; align-items: stretch; }
+    .att-panel-header h5 { margin-bottom: 0.5rem; }
+    .att-btn-group { width: 100%; }
+    .att-btn-group .btn { flex: 1 1 0; padding: 0.5rem 0.5rem; font-size: 0.9rem; }
+}
 
 /* ── Upload form ─────────────────────────────────────────────────────────── */
 .att-upload-box {
@@ -166,7 +187,12 @@
                     <i class="mdi mdi-upload mr-1"></i><span class="d-none d-sm-inline">Upload from </span>PC
                 </button>
                 <button class="btn btn-sm btn-outline-info" type="button"
-                    onclick="attShowQr('{{ $panelId }}', '{{ $tokenRoute }}')">
+                    @if($pendingMode)
+                    onclick="attShowQrUrl('{{ $panelId }}', '{{ $mobileUploadUrl }}')"
+                    @else
+                    onclick="attShowQr('{{ $panelId }}', '{{ $tokenRoute }}')"
+                    @endif
+                    >
                     <i class="mdi mdi-qrcode mr-1"></i><span class="d-none d-sm-inline">QR </span>Mobile
                 </button>
             </div>
@@ -200,7 +226,7 @@
                 </div>
                 <div>
                     <button class="btn btn-success btn-sm att-upload-btn" type="button"
-                        onclick="attDoUpload('{{ $panelId }}','{{ $storeRoute }}','{{ $attachableType }}','{{ $attachableId }}','{{ csrf_token() }}')">
+                        onclick="attDoUpload('{{ $panelId }}','{{ $storeRoute }}','{{ $attachableType }}','{{ $pendingMode ? '' : $attachableId }}','{{ csrf_token() }}','{{ $pendingMode ? $pendingToken : '' }}')">
                         <i class="mdi mdi-cloud-upload mr-1"></i>Upload
                     </button>
                 </div>
@@ -297,44 +323,112 @@ function attToggleUpload(pid) {
     document.getElementById('att-qr-' + pid).style.display = 'none';
 }
 
-function attShowQr(pid, tokenRoute) {
-    const qrPanel  = document.getElementById('att-qr-' + pid);
-    const loading  = document.getElementById('att-qrloading-' + pid);
-    const qrBox    = document.getElementById('att-qrbox-' + pid);
-    const qrLink   = document.getElementById('att-qrlink-' + pid);
-
+function attOpenQrPanel(pid) {
+    const qrPanel = document.getElementById('att-qr-' + pid);
     document.getElementById('att-upload-' + pid).style.display = 'none';
     qrPanel.style.display = 'block';
     qrPanel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+}
 
-    if (window._vmQrCache[pid]) {
-        loading.style.display = 'none';
-        return;
-    }
+function attDrawQr(pid, url) {
+    const loading = document.getElementById('att-qrloading-' + pid);
+    const qrBox   = document.getElementById('att-qrbox-' + pid);
+    const qrLink  = document.getElementById('att-qrlink-' + pid);
+    loading.style.display = 'none';
+    qrBox.innerHTML = '';
+    qrLink.href = url;
+    new QRCode(qrBox, {
+        text: url,
+        width: 200, height: 200,
+        colorDark: '#111827', colorLight: '#ffffff',
+        correctLevel: QRCode.CorrectLevel.M
+    });
+    window._vmQrCache[pid] = url;
+}
+
+// Linked mode: fetch a fresh token from the server, then draw the QR.
+function attShowQr(pid, tokenRoute) {
+    attOpenQrPanel(pid);
+    const loading = document.getElementById('att-qrloading-' + pid);
+
+    if (window._vmQrCache[pid]) { loading.style.display = 'none'; return; }
 
     loading.style.display = 'block';
-    qrBox.innerHTML = '';
+    document.getElementById('att-qrbox-' + pid).innerHTML = '';
 
     fetch(tokenRoute, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
         .then(r => r.json())
         .then(data => {
             if (!data.success) throw new Error('failed');
-            loading.style.display = 'none';
-            qrLink.href = data.upload_url;
-            new QRCode(qrBox, {
-                text: data.upload_url,
-                width: 200, height: 200,
-                colorDark: '#111827', colorLight: '#ffffff',
-                correctLevel: QRCode.CorrectLevel.M
-            });
-            window._vmQrCache[pid] = data.upload_url;
+            attDrawQr(pid, data.upload_url);
         })
         .catch(() => {
             loading.innerHTML = '<span class="text-danger"><i class="mdi mdi-alert-circle mr-1"></i>Could not generate link. Please refresh.</span>';
         });
 }
 
-function attDoUpload(pid, storeRoute, type, id, csrf) {
+// Pending mode: the mobile URL is already known, so draw the QR immediately.
+function attShowQrUrl(pid, url) {
+    attOpenQrPanel(pid);
+    if (window._vmQrCache[pid]) { document.getElementById('att-qrloading-' + pid).style.display = 'none'; return; }
+    attDrawQr(pid, url);
+}
+
+function attEnsureGrid(pid) {
+    let grid = document.getElementById('att-grid-' + pid);
+    if (!grid) {
+        document.getElementById('att-list-' + pid).innerHTML =
+            `<div class="att-grid" id="att-grid-${pid}"></div>`;
+        grid = document.getElementById('att-grid-' + pid);
+    }
+    const empty = document.getElementById('att-empty-' + pid);
+    if (empty) empty.style.display = 'none';
+    return grid;
+}
+
+function attBumpBadge(pid, delta) {
+    const panel = document.getElementById('att-panel-' + pid);
+    if (!panel) return;
+    const h5 = panel.querySelector('.att-panel-header h5');
+    if (!h5) return;
+    let badge = h5.querySelector('.badge');
+    if (badge) {
+        const next = (parseInt(badge.textContent, 10) || 0) + delta;
+        if (next <= 0) badge.remove(); else badge.textContent = next;
+    } else if (delta > 0) {
+        const b = document.createElement('span');
+        b.className = 'badge badge-primary ml-1';
+        b.textContent = delta;
+        h5.appendChild(b);
+    }
+}
+
+function attRenderCard(grid, att, csrf) {
+    if (!grid || document.getElementById('att-item-' + att.id)) return; // de-dupe (polling)
+    const card = document.createElement('div');
+    card.className = 'att-card';
+    card.id = 'att-item-' + att.id;
+    const fname = att.file_name.length > 24 ? att.file_name.substring(0, 24) + '…' : att.file_name;
+    card.innerHTML = `
+        ${att.is_image
+            ? `<a href="${att.url}" target="_blank" class="d-block w-100"><img src="${att.url}" class="att-thumb" alt="${att.file_name}"></a>`
+            : `<a href="${att.url}" target="_blank"><img src="/assets/images/pdf-file.svg" class="att-thumb-pdf" alt="PDF"></a>`}
+        ${att.label ? `<span class="badge badge-info att-label-badge">${att.label}</span>` : ''}
+        <div class="att-filename">${fname}</div>
+        <div class="att-filesize">${att.formatted_size}</div>
+        <div class="att-actions">
+            <a href="${att.url}" target="_blank" class="btn btn-xs btn-outline-primary mr-1">
+                <i class="mdi mdi-eye"></i>
+            </a>
+            <button type="button" class="btn btn-xs btn-outline-danger" onclick="attDelete(${att.id},'${csrf}')">
+                <i class="mdi mdi-delete"></i>
+            </button>
+        </div>`;
+    grid.prepend(card);
+}
+
+// Works for both linked mode (type+id) and pending mode (upload token).
+function attDoUpload(pid, storeRoute, type, id, csrf, token) {
     const fileInput  = document.getElementById('att-file-' + pid);
     const labelInput = document.getElementById('att-label-' + pid);
     const progress   = document.getElementById('att-progress-' + pid);
@@ -348,8 +442,12 @@ function attDoUpload(pid, storeRoute, type, id, csrf) {
 
     const fd = new FormData();
     Array.from(fileInput.files).forEach(f => fd.append('files[]', f));
-    fd.append('attachable_type', type);
-    fd.append('attachable_id',   id);
+    if (token && !id) {
+        fd.append('upload_token', token);
+    } else {
+        fd.append('attachable_type', type);
+        fd.append('attachable_id', id);
+    }
     if (labelInput.value) fd.append('label', labelInput.value);
     fd.append('_token', csrf);
 
@@ -364,64 +462,20 @@ function attDoUpload(pid, storeRoute, type, id, csrf) {
     };
     xhr.onload = () => {
         bar.style.width = '100%';
-        const res = JSON.parse(xhr.responseText);
+        let res = {};
+        try { res = JSON.parse(xhr.responseText); } catch (e) { res = {}; }
         if (xhr.status === 200 && res.success) {
-            msg.innerHTML = `<div class="alert alert-success py-1 px-2 small mb-0">
-                ✅ ${res.attachments.length} file(s) uploaded.
-                <a href="javascript:location.reload()">Refresh</a> to see all.
-            </div>`;
+            msg.innerHTML = `<div class="alert alert-success py-1 px-2 small mb-0">✅ ${res.attachments.length} file(s) added.</div>`;
             fileInput.value = '';
             const lbl = document.querySelector(`label[for="att-file-${pid}"]`);
             if (lbl) lbl.textContent = 'Choose files…';
 
-            const empty = document.getElementById('att-empty-' + pid);
-            if (empty) empty.style.display = 'none';
-
-            // Update the badge count in the panel header
-            const panel = document.getElementById('att-panel-' + pid);
-            if (panel) {
-                const h5 = panel.querySelector('.att-panel-header h5');
-                let badge = h5 ? h5.querySelector('.badge') : null;
-                const addedCount = res.attachments.length;
-                if (badge) {
-                    badge.textContent = (parseInt(badge.textContent, 10) || 0) + addedCount;
-                } else if (h5) {
-                    const b = document.createElement('span');
-                    b.className = 'badge badge-primary ml-1';
-                    b.textContent = addedCount;
-                    h5.appendChild(b);
-                }
-            }
-
-            let grid = document.getElementById('att-grid-' + pid);
-            if (!grid) {
-                document.getElementById('att-list-' + pid).innerHTML =
-                    `<div class="att-grid" id="att-grid-${pid}"></div>`;
-                grid = document.getElementById('att-grid-' + pid);
-            }
-
+            const grid = attEnsureGrid(pid);
             res.attachments.forEach(att => {
-                const card = document.createElement('div');
-                card.className = 'att-card';
-                card.id = 'att-item-' + att.id;
-                const fname = att.file_name.length > 24 ? att.file_name.substring(0, 24) + '…' : att.file_name;
-                card.innerHTML = `
-                    ${att.is_image
-                        ? `<a href="${att.url}" target="_blank" class="d-block w-100"><img src="${att.url}" class="att-thumb" alt="${att.file_name}"></a>`
-                        : `<a href="${att.url}" target="_blank"><img src="/assets/images/pdf-file.svg" class="att-thumb-pdf" alt="PDF"></a>`}
-                    ${att.label ? `<span class="badge badge-info att-label-badge">${att.label}</span>` : ''}
-                    <div class="att-filename">${fname}</div>
-                    <div class="att-filesize">${att.formatted_size}</div>
-                    <div class="att-actions">
-                        <a href="${att.url}" target="_blank" class="btn btn-xs btn-outline-primary mr-1">
-                            <i class="mdi mdi-eye"></i>
-                        </a>
-                        <button type="button" class="btn btn-xs btn-outline-danger"
-                            onclick="attDelete(${att.id},'${csrf}')">
-                            <i class="mdi mdi-delete"></i>
-                        </button>
-                    </div>`;
-                grid.prepend(card);
+                if (!document.getElementById('att-item-' + att.id)) {
+                    attRenderCard(grid, att, csrf);
+                    attBumpBadge(pid, 1);
+                }
             });
         } else {
             const err = res.errors
@@ -462,21 +516,11 @@ function attDelete(attId, csrf) {
                 const panel = el.closest('[id^="att-panel-"]');
                 el.remove();
 
-                // Update the badge count in the panel header
                 if (panel) {
-                    const badge = panel.querySelector('.att-panel-header h5 .badge');
-                    if (badge) {
-                        const current = parseInt(badge.textContent, 10) || 0;
-                        const next = current - 1;
-                        if (next <= 0) {
-                            badge.remove();
-                        } else {
-                            badge.textContent = next;
-                        }
-                    }
+                    const pid = panel.id.replace('att-panel-', '');
+                    attBumpBadge(pid, -1);
 
                     // If the grid is now empty, swap it for the empty-state message
-                    const pid = panel.id.replace('att-panel-', '');
                     const grid = document.getElementById('att-grid-' + pid);
                     if (grid && grid.children.length === 0) {
                         const list = document.getElementById('att-list-' + pid);
@@ -499,6 +543,29 @@ function attDelete(attId, csrf) {
     });
 }
 
+// Pending mode: poll the server so files uploaded from the phone (QR) appear here live.
+window._attPollers = window._attPollers || {};
+function attStartPendingPoll(pid, listUrl, csrf) {
+    if (!listUrl || window._attPollers[pid]) return;
+    window._attPollers[pid] = setInterval(() => {
+        fetch(listUrl, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+            .then(r => r.json())
+            .then(data => {
+                if (!data.success || !Array.isArray(data.attachments) || !data.attachments.length) return;
+                const grid = attEnsureGrid(pid);
+                let added = 0;
+                data.attachments.forEach(att => {
+                    if (!document.getElementById('att-item-' + att.id)) {
+                        attRenderCard(grid, att, csrf);
+                        added++;
+                    }
+                });
+                if (added > 0) attBumpBadge(pid, added);
+            })
+            .catch(() => {});
+    }, 4000);
+}
+
 // Update custom-file-input label text
 document.querySelectorAll('.att-file-input').forEach(inp => {
     inp.addEventListener('change', function () {
@@ -512,3 +579,16 @@ document.querySelectorAll('.att-file-input').forEach(inp => {
 </script>
 @endpush
 @endonce
+
+{{-- Pending mode: start live polling so phone (QR) uploads appear on this screen --}}
+@if($pendingMode)
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    if (window.attStartPendingPoll) {
+        attStartPendingPoll('{{ $panelId }}', '{{ $listPendingUrl }}', '{{ csrf_token() }}');
+    }
+});
+</script>
+@endpush
+@endif

--- a/resources/views/invoice/add.blade.php
+++ b/resources/views/invoice/add.blade.php
@@ -51,6 +51,11 @@
 @endsection
 
 @section('content')
+    @php
+        // Same token is posted with the form and used by the documents panel below,
+        // so files uploaded before saving get linked to the new invoice on submit.
+        $docToken = old('upload_token', $uploadToken);
+    @endphp
     <div class="container-fluid">
         <!-- start page title -->
         <div class="row">
@@ -76,6 +81,7 @@
                             class="@if(count($errors)) was-validated @endif">
                             @csrf
                             <input type="hidden" name="invoice_no" value="{{ $lastId }}" />
+                            <input type="hidden" name="upload_token" value="{{ $docToken }}" />
 
                             <!-- Customer Info -->
                             <div class="row g-3">
@@ -192,6 +198,13 @@
                                     <input type="text" name="declaration" class="form-control form-control-sm"
                                     placeholder="Add any declaration or note" value="{{ old('declaration') }}">
                             </div>
+
+                            {{-- Customer Documents — attach now, linked automatically on save --}}
+                            @include('include.attachments-panel', [
+                                'attachableType' => 'invoice',
+                                'pendingMode'    => true,
+                                'pendingToken'   => $docToken,
+                            ])
 
                             <!-- Actions -->
                             <div class="d-flex justify-content-end mt-4">

--- a/resources/views/invoice/detail.blade.php
+++ b/resources/views/invoice/detail.blade.php
@@ -382,6 +382,19 @@
         </a>
     </div>
 
+    {{-- Customer Documents --}}
+    <div class="container-fluid mb-3">
+        <div class="row justify-content-center">
+            <div class="col-12" style="max-width: 210mm;">
+                @include('include.attachments-panel', [
+                    'attachable'     => $invoice,
+                    'attachableType' => 'invoice',
+                    'attachableId'   => $invoice->id,
+                ])
+            </div>
+        </div>
+    </div>
+
     <div class="page-container">
         <div class="invoice-box">
             <div class="invoice-body">

--- a/resources/views/invoice/edit.blade.php
+++ b/resources/views/invoice/edit.blade.php
@@ -219,6 +219,13 @@
                                 </button>
                             </div>
                         </form>
+
+                        {{-- Customer Documents --}}
+                        @include('include.attachments-panel', [
+                            'attachable'     => $invoice,
+                            'attachableType' => 'invoice',
+                            'attachableId'   => $invoice->id,
+                        ])
                     </div>
                 </div>
             </div>

--- a/routes/console.php
+++ b/routes/console.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+// Clean up abandoned pending document uploads (attached on Create but never saved).
+Schedule::command('attachments:purge-pending')->daily();

--- a/routes/web.php
+++ b/routes/web.php
@@ -197,6 +197,9 @@ Route::middleware(['auth'])->prefix('attachments')->name('attachments.')->group(
     Route::delete('/{id}', [AttachmentController::class, 'destroy'])->name('destroy');
     Route::get('/token/{type}/{id}', [AttachmentController::class, 'generateToken'])->name('token');
 
+    // Pending uploads (Create screen polls this so phone/QR uploads appear live)
+    Route::get('/pending/{token}', [AttachmentController::class, 'listPending'])->name('pending');
+
     // Documents Manager (view + export)
     Route::get('/documents', [AttachmentController::class, 'docIndex'])
         ->middleware('permission:attachments.view')


### PR DESCRIPTION
Documents can now be attached on the Create Invoice screen (from PC and via phone/QR) before the invoice is saved, using a pending upload-session token that links files to the invoice on submit. Also surfaces the documents panel on the invoice edit and detail pages, adds live polling so phone uploads appear on the create screen, a daily cleanup command for abandoned pending uploads, and a mobile-friendly panel button layout.